### PR TITLE
fix links in chapter_05.md

### DIFF
--- a/docs/chapters/chapter_05.md
+++ b/docs/chapters/chapter_05.md
@@ -128,7 +128,7 @@ Two types of PIDs are used when sharing materials from our events.
     width="500" alt="Screenshot of an Australian BioCommons training record in Zenodo highlighting the use of ORCIDs and DOI"/>
 </figure>
 
-**Figure 1:** The Australian BioCommons collates materials from their events and shares them via Zenodo where they are assigned a DOI and authors are identified via their ORCIDs. [View this record on Zenodo.](https://zenodo.org/record/6350808#.YkPhE25Bw3Q)
+**Figure 1:** The Australian BioCommons collates materials from their events and shares them via Zenodo where they are assigned a DOI and authors are identified via their ORCIDs. [View this record on Zenodo.](https://zenodo.org/doi/10.5281/zenodo.5781811)
 
 ### 2. Creating virtual collections of training materials and assigning own PIDs
 For [CLARIN](https://www.clarin.eu/), a training event usually consists of slides, handouts, a GitHub page, video tutorials, language resources, datasets and/or tools. The slides and handouts are published on the event web page, while the video recordings of the presentations are published on the CLARIN YouTube channel. In addition, the language resources and tools used during the training are stored in the CLARIN national repositories, with a **unique** identifier assigned by the institution and can be cited.
@@ -163,7 +163,7 @@ The [Dutch Techcentre for Life Sciences](https://www.dtls.nl/) (DTL) has a [Zeno
 
 Providing a separate DOI has the following advantages: It is easier to mix and match different modules as part of a learning path, i.e. different combinations of our training modules can be made for the various target audiences, tailored to that specific purpose. When updating or revising a single module, it is more convenient to have that module as a separate entity with its own DOI, in order to easily keep track of the versions of different modules.
 
-At the level of the full course, we have chosen to use ELIXIR TeSS as the registry. Links to our training event details and training materials can be found [here(https://tess.elixir-europe.org/events/helis-course-fair-data-stewardship).
+At the level of the full course, we have chosen to use ELIXIR TeSS as the registry. Links to our training event details and training materials can be found [here](https://tess.elixir-europe.org/events/helis-course-fair-data-stewardship).
 
 <figure>
     <img src="../../assets/images/fig4-chap5.png"

--- a/docs/chapters/chapter_05.md
+++ b/docs/chapters/chapter_05.md
@@ -134,7 +134,7 @@ Two types of PIDs are used when sharing materials from our events.
 For [CLARIN](https://www.clarin.eu/), a training event usually consists of slides, handouts, a GitHub page, video tutorials, language resources, datasets and/or tools. The slides and handouts are published on the event web page, while the video recordings of the presentations are published on the CLARIN YouTube channel. In addition, the language resources and tools used during the training are stored in the CLARIN national repositories, with a **unique** identifier assigned by the institution and can be cited.
 
 
-One solution to have a PID assigned to all the materials used during one training event is to create a virtual collection in the CLARIN [Virtual Collection Registry](https://collections.clarin.eu/public?7). A virtual collection is a coherent set of links of digital objects that can be easily created, accessed and cited with the help of **unique identifiers**, for example, a DOI. The links can originate from different archives. (Here)[http://hdl.handle.net/11372/VC-1033] is an example of a virtual collection created for a hands-on tutorial on transcribing interview data
+One solution to have a PID assigned to all the materials used during one training event is to create a virtual collection in the CLARIN [Virtual Collection Registry](https://collections.clarin.eu/public?7). A virtual collection is a coherent set of links of digital objects that can be easily created, accessed and cited with the help of **unique identifiers**, for example, a DOI. The links can originate from different archives. [Here](http://hdl.handle.net/11372/VC-1033) is an example of a virtual collection created for a hands-on tutorial on transcribing interview data
 
 <figure>
     <img src="../../assets/images/clarin_image1.png"
@@ -151,6 +151,7 @@ One solution to have a PID assigned to all the materials used during one trainin
 
 
 Other practices that the trainers in the CLARIN community have adopted are:
+
 - First, depositing the training materials together with the datasets in their CLARIN national data repository. See example:[Archilochus of Paros: Elegiac Fragments - XML Archive](http://hdl.handle.net/20.500.11752/OPEN-537). The advantage of using this path is that the authors can add more extensive metadata to describe their materials. 
 - Second, depositing the training materials on Zenodo. See example: [Introduction to Speech Analysis](https://doi.org/10.5281/zenodo.5506969).  In this case, **related identifiers** are included that lead users to the main platform where the course is stored and maintained. 
 - Third, adding the metadata of the training materials to the SSHOC Open Marketplace, see example: [Jupyter notebooks for Europeana newspaper text resource processing with CLARIN NLP tools](https://marketplace.sshopencloud.eu/training-material/duVII1). In this case, the Marketplace does not assign any unique identifiers, but the authors can identify themselves via their ORCID and can suggest a citation format for their collection.


### PR DESCRIPTION
I found some links that were problematic
- "View this record on Zenodo" under figure1 in chapter 5 linked to another Zenodo record than was shown in the figure
- Link to Tess for use case 3 was not formatted properly
- Link to the example of a virtual collection created for a hands-on tutorial on transcribing interview data was not formatted correctly